### PR TITLE
Water boundary prototype

### DIFF
--- a/Assets/Materials/WaterBoundary.mat
+++ b/Assets/Materials/WaterBoundary.mat
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: WaterBoundary
+  m_Shader: {fileID: 4800000, guid: c5e7ca4a9f5fa9a48b096e67508a921e, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _StateTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DepthDecay: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _NormalStrength: 1.9
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _Smoothness: 0
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0.08360688, b: 0.1981132, a: 0.85882354}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/WaterBoundary.mat.meta
+++ b/Assets/Materials/WaterBoundary.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e72cc0628d750ef469589d7be7ed5d90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/CustomTerrain/CustomTerrain.unity
+++ b/Assets/Scenes/CustomTerrain/CustomTerrain.unity
@@ -341,6 +341,7 @@ MonoBehaviour:
   Materials:
   - {fileID: 2100000, guid: 1cf9e6530b1beb341b6ecccf254cf279, type: 2}
   - {fileID: 2100000, guid: 4dc86583f8ebc4d44be01aada5cc6c14, type: 2}
+  - {fileID: 2100000, guid: e72cc0628d750ef469589d7be7ed5d90, type: 2}
   ErosionComputeShader: {fileID: 7200000, guid: fcfc55914f9fdb646be1044044c2d042,
     type: 3}
   InitialState: {fileID: 2800000, guid: 43149b43056f9c340b49f9a408fc3284, type: 3}
@@ -379,6 +380,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1427476926
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1427476928}
+  - component: {fileID: 1427476927}
+  m_Layer: 0
+  m_Name: WaterBoundaries
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1427476927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427476926}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ebdd905ab35049e6b8ab362d30c0b560, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Size: {x: 512, y: 100, z: 512}
+  Material: {fileID: 2100000, guid: e72cc0628d750ef469589d7be7ed5d90, type: 2}
+  Resolution: {x: 512, y: 512}
+--- !u!4 &1427476928
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427476926}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1533200768
 GameObject:

--- a/Assets/Scripts/ChunkedPlane.cs
+++ b/Assets/Scripts/ChunkedPlane.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Assets.Scripts.Utils;
 using UnityEngine;
 using UnityEngine.Rendering;
+using Utils;
 
 public class ChunkedPlane : MonoBehaviour
 {
@@ -105,7 +106,7 @@ public class ChunkedPlane : MonoBehaviour
 
     private GameObject GenerateChunk(Vector3 chunkSize, Vector2 uvStart, Vector2 uvEnd, ChunkLODSetting settings, int lodLevel)
     {
-        var chunkObject = new GameObject(string.Format("Terrain_Chunk_LOD{0}", lodLevel));
+        var chunkObject = new GameObject($"Terrain_Chunk_LOD{lodLevel}");
         var chunkMeshFilter = chunkObject.AddComponent<MeshFilter>();
         var chunkMeshRenderer = chunkObject.AddComponent<MeshRenderer>();
 

--- a/Assets/Scripts/Utils/MeshUtils.cs
+++ b/Assets/Scripts/Utils/MeshUtils.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 
-namespace Assets.Scripts.Utils
+namespace Utils
 {
     public static class MeshUtils
     {
@@ -11,13 +10,13 @@ namespace Assets.Scripts.Utils
             var normals = new Vector3[vertices.Length];
             var uvs = new Vector2[vertices.Length];
             var triangles = new int[(axis0Vertices - 1) * (axis1Vertices - 1) * 2 * 3];
-            var normal = Vector3.Cross(axis1, axis0);
+            var normal = Vector3.Cross(axis1, axis0).normalized;
 
             // Vertices
             for (var i = 0; i < vertices.Length; i++)
             {
-                var i0 = i / axis0Vertices;
-                var i1 = i % axis0Vertices;
+                var i0 = i / axis1Vertices;
+                var i1 = i % axis1Vertices;
                 var localU = i0 / (axis0Vertices - 1f);
                 var localV = i1 / (axis1Vertices - 1f);
 
@@ -33,21 +32,21 @@ namespace Assets.Scripts.Utils
             {
                 for (var i1 = 0; i1 < axis1Vertices - 1; i1++)
                 {
-                    triangles[vertexIndex++] = (i0 + 0) * axis0Vertices + (i1 + 0);
-                    triangles[vertexIndex++] = (i0 + 1) * axis0Vertices + (i1 + 1);
-                    triangles[vertexIndex++] = (i0 + 1) * axis0Vertices + (i1 + 0);
+                    triangles[vertexIndex++] = (i0 + 0) * axis1Vertices + (i1 + 0);
+                    triangles[vertexIndex++] = (i0 + 1) * axis1Vertices + (i1 + 1);
+                    triangles[vertexIndex++] = (i0 + 1) * axis1Vertices + (i1 + 0);
 
-                    triangles[vertexIndex++] = (i0 + 0) * axis0Vertices + (i1 + 0);
-                    triangles[vertexIndex++] = (i0 + 0) * axis0Vertices + (i1 + 1);
-                    triangles[vertexIndex++] = (i0 + 1) * axis0Vertices + (i1 + 1);
+                    triangles[vertexIndex++] = (i0 + 0) * axis1Vertices + (i1 + 0);
+                    triangles[vertexIndex++] = (i0 + 0) * axis1Vertices + (i1 + 1);
+                    triangles[vertexIndex++] = (i0 + 1) * axis1Vertices + (i1 + 1);
                 }
             }
 
             var mesh = new Mesh()
             {
-                name = string.Format("Plane_{0}x{1}", axis0Vertices, axis1Vertices),
+                name = $"Plane_{axis0Vertices}x{axis1Vertices}",
                 vertices = vertices,
-                //normals = normals,
+                normals = normals,
                 uv = uvs,
                 triangles = triangles
             };

--- a/Assets/Scripts/WaterBoundary.cs
+++ b/Assets/Scripts/WaterBoundary.cs
@@ -1,0 +1,41 @@
+using System;
+using UnityEngine;
+using Utils;
+
+public class WaterBoundary : MonoBehaviour
+{
+    // Should match terrain size
+    public Vector3 Size;
+    
+    // Material with a special WaterBoundary shader
+    public Material Material;
+    
+    // Resolution should match state - texture resolution 
+    public Vector2Int Resolution = new Vector2Int(512, 512);
+
+    void Start()
+    {
+        CreatePlane("Back(Near)", new Vector3(0, 0,0), Vector3.right * Size.x, Resolution.x);
+        CreatePlane("Front(Far)", new Vector3(Size.x, 0, Size.z), Vector3.left * Size.x, Resolution.x);
+        CreatePlane("Left", new Vector3(0, 0, Size.z),  Vector3.back * Size.z, Resolution.x);
+        CreatePlane("Right", new Vector3(Size.x, 0, 0), Vector3.forward * Size.z, Resolution.x);
+        
+        Material.SetVector("_WorldScale", Size);
+    }
+
+    void CreatePlane(string objectName, Vector3 origin, Vector3 horizontalAxis, int resolution)
+    {
+        var mesh = MeshUtils.GeneratePlane(Vector3.zero, horizontalAxis,
+            new Vector3(0, Size.y, 0),
+            resolution,
+            2,
+            Vector2.zero,
+            Vector2.one);
+        
+        var go = new GameObject(objectName);
+        go.AddComponent<MeshFilter>().sharedMesh = mesh;
+        go.AddComponent<MeshRenderer>().material = Material;
+        go.transform.SetParent(transform);
+        go.transform.localPosition = origin;
+    }
+}

--- a/Assets/Scripts/WaterBoundary.cs.meta
+++ b/Assets/Scripts/WaterBoundary.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebdd905ab35049e6b8ab362d30c0b560
+timeCreated: 1584476972

--- a/Assets/Shaders/WaterBoundary.shader
+++ b/Assets/Shaders/WaterBoundary.shader
@@ -1,0 +1,81 @@
+﻿Shader "Custom/WaterBoundary" {
+	Properties{		
+		_Color("Color", Color) = (0, 0, 1, 0.8)
+		[NoScaleOffset] _StateTex("State", 2D) = "black" {}		
+	}
+		
+	SubShader
+	{
+		Tags { "Queue"="Transparent"  "RenderType"="Transparent"  "IgnoreProjector"="True" }
+
+		Pass
+		{
+			Tags {"LightMode" = "ForwardBase" "IgnoreProjector" = "True" }
+			//LOD 300
+			Blend SrcAlpha OneMinusSrcAlpha
+			//Zwrite Off
+
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#include "UnityCG.cginc"
+			#include "Lighting.cginc"
+			#include "UnityPBSLighting.cginc"
+
+			// compile shader into multiple variants, with and without shadows
+			// (we don't care about any lightmaps yet, so skip these variants)
+			#pragma multi_compile_fwdbase nolightmap nodirlightmap nodynlightmap novertexlight multi_compile_fog			
+			#include "AutoLight.cginc"
+
+			struct v2f
+			{				
+				float2 uvState : TEXCOORD0;
+				float4 pos : SV_POSITION;
+				float3 worldPos : TEXCOORD1;
+				float4 screenPos : TEXCOORD2;
+				SHADOW_COORDS(3)
+				UNITY_FOG_COORDS(4)
+			};
+			
+			sampler2D _StateTex;
+			float2 _StateTex_TexelSize;			
+			float3 _WorldScale;
+			fixed4 _Color;
+
+			#define WATER_HEIGHT(s) (s.g)
+			#define TERRAIN_HEIGHT(s) (s.r)
+			#define FULL_HEIGHT(s) (TERRAIN_HEIGHT(s) + WATER_HEIGHT(s))
+
+			v2f vert(appdata_base v)
+			{
+			    float4 worldPos = mul(unity_ObjectToWorld, v.vertex);			
+			    
+			    // Notice that state is sample at uv = worldPos / _WorldScale
+				float4 state = tex2Dlod(_StateTex, float4(worldPos.x / _WorldScale.x, worldPos.z / _WorldScale.z, 0, 0));
+				
+				// if mesh uv.y is 0 - then y of vertex = terrain, if 1 then y of vertex = water
+				v.vertex.y = TERRAIN_HEIGHT(state) + v.texcoord.y * WATER_HEIGHT(state);
+
+				v2f o;
+				o.pos = UnityObjectToClipPos(v.vertex);				
+				o.uvState = v.texcoord;
+				o.worldPos = mul(unity_ObjectToWorld, v.vertex);
+				o.screenPos = ComputeScreenPos(o.pos);
+
+				TRANSFER_SHADOW(o)
+				UNITY_TRANSFER_FOG(o, o.pos);
+				return o;
+			}
+
+			fixed4 frag(v2f i) : SV_Target
+			{				
+			    // return simple Color
+			    // TODO: Adapt water shader 
+			    return _Color;
+			}
+			ENDCG
+		}
+	}
+
+	Fallback "Diffuse"		
+}

--- a/Assets/Shaders/WaterBoundary.shader.meta
+++ b/Assets/Shaders/WaterBoundary.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c5e7ca4a9f5fa9a48b096e67508a921e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Water boundary prototype.

Allows to generate 4 planes at each side of terrain-enclosing bounds, where horizontal dimension should equal to the state texture resolution and there are only 2 vertices.

Y coordinate of the vertices is set in the vertex shader (see WaterBoundary) depending on a texture and UV of the texture. UV.y = 0 maps to the terrain height, UV.y = 1 maps to water level.

There are still several issues:
- Boundary & terrain mismatch at different LOD levels and resolutions
- No Lighting on boundary

Closing #2 
